### PR TITLE
remove z-index of sup

### DIFF
--- a/components/ui/MarkdownContent/stylesheets/table.scss
+++ b/components/ui/MarkdownContent/stylesheets/table.scss
@@ -67,9 +67,6 @@
       border: 0;
       vertical-align: top;
 
-      sup {
-        z-index: -1;
-      }
     }
 
     // markdown that has been converted to HTML is often wrapped in <p> tags


### PR DESCRIPTION
### Why:

Closes: #26725

### What's being changed (if available, include any code snippets, screenshots, or gifs):
`Before:`
![image](https://github.com/vats147/docs/assets/89577062/f388777f-3b4a-42bf-bf95-f5a4f50c93ec)


`After:`
![image](https://github.com/vats147/docs/assets/89577062/94fee5ee-39f0-467e-bc10-bf1d8cf773a6)


as you clearly see `superscript` text is not visible beacuse of `z-index:-1`

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
